### PR TITLE
Add DOM-safe rendering helpers.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM php:7.3-apache
 
-ENV APACHE_DOCUMENT_ROOT /mudmaker
+ENV APACHE_DOCUMENT_ROOT=/mudmaker
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates git && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf && \
     sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf && \
@@ -8,6 +12,13 @@ RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-av
     sed -ri -e 's!80!8080!g' /etc/apache2/ports.conf
 
 COPY . /mudmaker/
+
+RUN rm -rf /mudmaker/mud-visualizer /mudmaker/scripts /mudmaker/img /mudmaker/css /mudmaker/renderer.js && \
+    git clone --depth 1 https://github.com/iot-onboarding/mud-visualizer.git /mudmaker/mud-visualizer && \
+    ln -s mud-visualizer/scripts /mudmaker/scripts && \
+    ln -s mud-visualizer/img /mudmaker/img && \
+    ln -s mud-visualizer/css /mudmaker/css && \
+    ln -s mud-visualizer/renderer.js /mudmaker/renderer.js
 
 CMD ["apache2-foreground"]
 ENTRYPOINT ["docker-php-entrypoint"]

--- a/assets/js/dom-safe.js
+++ b/assets/js/dom-safe.js
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2017-2025 Eliot Lear
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+(function(global) {
+    "use strict";
+
+    function nodeFor(target) {
+        if (typeof target === "string") {
+            return document.getElementById(target);
+        }
+        return target;
+    }
+
+    function asTextNode(value) {
+        return document.createTextNode(value == null ? "" : String(value));
+    }
+
+    function clear(target) {
+        var node = nodeFor(target);
+        if (!node) {
+            return null;
+        }
+        while (node.firstChild) {
+            node.removeChild(node.firstChild);
+        }
+        return node;
+    }
+
+    function append(parent) {
+        var node = nodeFor(parent);
+        if (!node) {
+            return null;
+        }
+        Array.prototype.slice.call(arguments, 1).forEach(function(child) {
+            if (child == null) {
+                return;
+            }
+            node.appendChild(child.nodeType ? child : asTextNode(child));
+        });
+        return node;
+    }
+
+    function applyAttrs(node, attrs) {
+        if (!attrs) {
+            return node;
+        }
+        Object.keys(attrs).forEach(function(key) {
+            var value = attrs[key];
+            if (value == null || value === false) {
+                return;
+            }
+            if (/^on/i.test(key)) {
+                throw new Error("Event handler attributes are not allowed");
+            }
+            if (key === "className") {
+                node.className = String(value);
+            } else if (key === "text") {
+                node.appendChild(asTextNode(value));
+            } else if (key === "style" && typeof value === "object") {
+                Object.keys(value).forEach(function(styleName) {
+                    node.style[styleName] = value[styleName];
+                });
+            } else {
+                node.setAttribute(key, value === true ? key : String(value));
+            }
+        });
+        return node;
+    }
+
+    function element(tagName, attrs) {
+        var node = document.createElement(tagName);
+        applyAttrs(node, attrs);
+        append.apply(null, [node].concat(Array.prototype.slice.call(arguments, 2)));
+        return node;
+    }
+
+    function isSafeHref(href) {
+        var url;
+        if (typeof href !== "string" || href === "") {
+            return false;
+        }
+        if (href.charAt(0) === "#") {
+            return true;
+        }
+        try {
+            url = new URL(href, window.location.href);
+        } catch (e) {
+            return false;
+        }
+        return ["http:", "https:", "mailto:"].indexOf(url.protocol) !== -1;
+    }
+
+    function link(href, label, attrs) {
+        var node = element("a", attrs, label);
+        if (!isSafeHref(href)) {
+            throw new Error("Unsafe link target");
+        }
+        node.setAttribute("href", href);
+        if (node.getAttribute("target") === "_blank" && !node.getAttribute("rel")) {
+            node.setAttribute("rel", "noopener noreferrer");
+        }
+        return node;
+    }
+
+    function statusText(text, attrs) {
+        return element("span", attrs, text);
+    }
+
+    function listItem(label, value, attrs) {
+        var item = element("li", attrs);
+        append(item, label, ": ", value);
+        return item;
+    }
+
+    global.MudSafeDom = {
+        append: append,
+        clear: clear,
+        element: element,
+        link: link,
+        listItem: listItem,
+        statusText: statusText,
+        text: asTextNode
+    };
+})(window);

--- a/mudmaker.html
+++ b/mudmaker.html
@@ -27,6 +27,7 @@
     <!--[if lte IE 8]><script src="assets/js/ie/html5shiv.js"></script><![endif]-->
     <link rel="stylesheet" href="assets/css/main.css" defer="defer">
     <!--[if lte IE 9]><link rel="stylesheet" href="assets/css/ie9.css" /><![endif]-->
+    <script type="text/javascript" src="assets/js/dom-safe.js"></script>
     <script type="text/javascript" src="assets/js/mudmaker.js" defer="defer"></script>
     <script type="text/javascript" src="assets/js/tabs.js"></script>
     <script type="text/javascript" src="assets/js/omud.js"></script>

--- a/mudpublish.html
+++ b/mudpublish.html
@@ -25,6 +25,7 @@
     <title>How Devices Can Emit MUD URLs</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="assets/css/main.css">
+    <script type="text/javascript" src="assets/js/dom-safe.js"></script>
     <script type="text/javascript" src="assets/js/tabs.js"></script>
     <script type= "text/javascript" src="assets/js/omud.js"></script>
   </head>


### PR DESCRIPTION
   Add `assets/js/dom-safe.js` with helpers for status text, links, and list rows so UI updates can use `textContent`, `appendChild`, and explicit attributes instead of string-built `innerHTML`.