### PR TITLE
Potential fix for code scanning alert no. 10: Uncontrolled command line

### DIFF
--- a/gitmud/gitmud/app.py
+++ b/gitmud/gitmud/app.py
@@ -747,16 +747,33 @@ def pcap2mud():
                       "w", encoding="ascii") as fh:
                 fh.write(mac + "\n")
 
+        _SAFE_ARG_RE = re.compile(r"^[A-Za-z0-9._:/?#\[\]@!$&'()*+,;=%\- ]+$")
+        def _validated_cli_value(field_name, raw_value, max_len=512):
+            if raw_value is None:
+                return None
+            value = raw_value.strip()
+            if not value:
+                return None
+            if len(value) > max_len:
+                raise ValueError(f"{field_name} is too long")
+            if not _SAFE_ARG_RE.match(value):
+                raise ValueError(f"invalid characters in {field_name}")
+            return value
+
         argv = [sys.executable, str(script), workdir]
-        for opt, value in (
-            ("--mfg", request.form.get("mfg")),
-            ("--model", request.form.get("model")),
-            ("--systeminfo", request.form.get("systeminfo")),
-            ("--documentation", request.form.get("documentation")),
-            ("--mud-url", request.form.get("mud_url")),
-        ):
-            if value:
-                argv += [opt, value]
+        try:
+            for opt, field_name in (
+                ("--mfg", "mfg"),
+                ("--model", "model"),
+                ("--systeminfo", "systeminfo"),
+                ("--documentation", "documentation"),
+                ("--mud-url", "mud_url"),
+            ):
+                value = _validated_cli_value(field_name, request.form.get(field_name))
+                if value:
+                    argv += [opt, value]
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
 
         try:
             proc = subprocess.run(argv, capture_output=True,

--- a/gitmud/gitmud/app.py
+++ b/gitmud/gitmud/app.py
@@ -773,7 +773,8 @@ def pcap2mud():
                 if value:
                     argv += [opt, value]
         except ValueError as exc:
-            return jsonify({"error": str(exc)}), 400
+            log.warning("Invalid request parameters for mudgen_pcap invocation", exc_info=True)
+            return jsonify({"error": "Invalid request parameters"}), 400
 
         try:
             proc = subprocess.run(argv, capture_output=True,


### PR DESCRIPTION
Potential fix for [https://github.com/iot-onboarding/mudmaker/security/code-scanning/10](https://github.com/iot-onboarding/mudmaker/security/code-scanning/10)

Use strict allowlist validation for each user-provided optional argument before adding it to `argv`. Keep functionality the same by still allowing these fields, but reject values containing unsafe characters or excessive length.

Best fix in `gitmud/gitmud/app.py` (within the shown handler):
1. Define a small local validator function (or inline checks) that:
   - accepts only printable safe characters expected for metadata/URLs,
   - enforces reasonable max length,
   - rejects control characters/newlines.
2. Read each form value, validate it, and return HTTP 400 on invalid input.
3. Only append validated values to `argv`.

This addresses all variants because it breaks taint flow from `request.form` to `subprocess.run(argv, ...)` with explicit sanitization/validation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
