### PR TITLE
Potential fix for code scanning alert no. 1: Reflected server-side cross-site scripting

### DIFF
--- a/gitmud/gitmud/app.py
+++ b/gitmud/gitmud/app.py
@@ -15,7 +15,7 @@ import base64
 import configparser
 from pathlib import Path
 from time import sleep
-from flask import Flask,request, jsonify
+from flask import Flask,request, jsonify, escape
 import requests
 
 log = logging.getLogger("gitmud")
@@ -667,7 +667,7 @@ def do_the_rest():
     return {
         "mfg" : mfg,
         "model" : model,
-        "user" : user,
+        "user" : escape(user),
         "mudurl" : mudurl,
         "pcaps" : pcaps_result,
     }, 200


### PR DESCRIPTION
Potential fix for [https://github.com/iot-onboarding/mudmaker/security/code-scanning/1](https://github.com/iot-onboarding/mudmaker/security/code-scanning/1)

Use output encoding on reflected user-controlled strings before including them in the response.  
Best minimal fix here: escape `user` when building the returned payload in `do_the_rest()`.

In `gitmud/gitmud/app.py`:
- Update Flask import to include `escape`.
- In the return dict near lines 667–673, change `"user": user` to `"user": escape(user)`.

This preserves functionality (still returns the same field) while preventing dangerous characters from being reflected unescaped.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
