### PR TITLE
Potential fix for code scanning alert no. 9: Information exposure through an exception

### DIFF
--- a/gitmud/gitmud/app.py
+++ b/gitmud/gitmud/app.py
@@ -780,9 +780,10 @@ def pcap2mud():
 
         try:
             mud = json.loads(proc.stdout)
-        except json.JSONDecodeError as exc:
+        except json.JSONDecodeError:
+            log.exception("mudgen_pcap.py produced invalid JSON")
             return jsonify({
-                "error": f"mudgen_pcap.py produced invalid JSON: {exc}"
+                "error": "mudgen_pcap.py produced invalid JSON"
             }), 500
 
         notes = (proc.stderr or "").strip()


### PR DESCRIPTION
Potential fix for [https://github.com/iot-onboarding/mudmaker/security/code-scanning/9](https://github.com/iot-onboarding/mudmaker/security/code-scanning/9)

Use a generic error message in the HTTP response for JSON parse failures, and log the exception on the server for diagnostics.

Best fix in `gitmud/gitmud/app.py` around the `except json.JSONDecodeError as exc:` block (lines ~783–786):
- Keep catching the specific exception.
- Add a server-side log entry including exception context (`log.exception(...)`), which preserves debugging value without exposing details to clients.
- Replace the response body message so it does not include `exc` or any stack/parse internals.

No new dependencies are required; `logging` and `log` are already present.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
