### PR TITLE
Potential fix for code scanning alert no. 11: Unsafe jQuery plugin

### DIFF
--- a/assets/js/util.js
+++ b/assets/js/util.js
@@ -94,9 +94,15 @@
 
 			}, userConfig);
 
-			// Expand "target" if it's not a jQuery object already.
-				if (typeof config.target != 'jQuery')
-					config.target = $(config.target);
+			// Expand "target" safely if it's not a jQuery object already.
+				if (!(config.target instanceof jQuery)) {
+					if (config.target && (config.target.nodeType || config.target === window || config.target === document))
+						config.target = $(config.target);
+					else if (typeof config.target === 'string')
+						config.target = $($.find(config.target));
+					else
+						config.target = $this;
+				}
 
 		// Panel.
 

--- a/assets/js/util.js
+++ b/assets/js/util.js
@@ -96,12 +96,17 @@
 
 			// Expand "target" safely if it's not a jQuery object already.
 				if (!(config.target instanceof jQuery)) {
-					if (config.target && (config.target.nodeType || config.target === window || config.target === document))
+					if (config.target && (config.target.nodeType || config.target === window || config.target === document)) {
 						config.target = $(config.target);
-					else if (typeof config.target === 'string')
+					}
+					else if (typeof config.target === 'string') {
+						// Use $.find so string input is always treated as a selector, never as HTML.
 						config.target = $($.find(config.target));
-					else
+					}
+					else {
+						// Fallback for unsupported/untrusted types.
 						config.target = $this;
+					}
 				}
 
 		// Panel.

--- a/assets/js/util.js
+++ b/assets/js/util.js
@@ -100,10 +100,12 @@
 						// Treat string input strictly as a selector, never as HTML.
 						config.target = $($.find(config.target));
 					}
-					else if (config.target && typeof config.target === 'object' &&
-						(config.target.nodeType || config.target === window || config.target === document)) {
-						// Allow only concrete DOM/window/document objects.
-						config.target = $(config.target);
+					else if (config.target && typeof config.target === 'object') {
+						// Allow only real DOM Element/Document nodes or window.
+						if (config.target === window || config.target.nodeType === 1 || config.target.nodeType === 9)
+							config.target = $(config.target);
+						else
+							config.target = $this;
 					}
 					else {
 						// Fallback for unsupported/untrusted types.

--- a/assets/js/util.js
+++ b/assets/js/util.js
@@ -96,12 +96,14 @@
 
 			// Expand "target" safely if it's not a jQuery object already.
 				if (!(config.target instanceof jQuery)) {
-					if (config.target && (config.target.nodeType || config.target === window || config.target === document)) {
-						config.target = $(config.target);
-					}
-					else if (typeof config.target === 'string') {
-						// Use $.find so string input is always treated as a selector, never as HTML.
+					if (typeof config.target === 'string') {
+						// Treat string input strictly as a selector, never as HTML.
 						config.target = $($.find(config.target));
+					}
+					else if (config.target && typeof config.target === 'object' &&
+						(config.target.nodeType || config.target === window || config.target === document)) {
+						// Allow only concrete DOM/window/document objects.
+						config.target = $(config.target);
 					}
 					else {
 						// Fallback for unsupported/untrusted types.


### PR DESCRIPTION
Potential fix for [https://github.com/iot-onboarding/mudmaker/security/code-scanning/11](https://github.com/iot-onboarding/mudmaker/security/code-scanning/11)

General fix: avoid passing untrusted strings to `$()` in plugin options where jQuery may interpret them as HTML. For plugin config fields like `target`, only accept safe types (jQuery object, DOM element, or selector resolved via `jQuery.find`), and fall back safely when invalid.

Best minimal fix in `assets/js/util.js` near lines 97–99:
- Replace the current `$(config.target)` expansion with guarded logic:
  - If already jQuery object: keep as-is.
  - If DOM node/window/document: wrap with `$()`.
  - If string: resolve with `$.find(config.target)` and wrap result with `$()` (selector-only path, no HTML parsing).
  - Otherwise: default to `$this`.

No new imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
