### PR TITLE
Potential fix for code scanning alert no. 8: Information exposure through an exception

### DIFF
--- a/gitmud/gitmud/app.py
+++ b/gitmud/gitmud/app.py
@@ -655,7 +655,10 @@ def do_the_rest():
             })
 
     except GithubProblem as e:
-        return str(e), 400
+        log.exception("GitHub operation failed during MUD/PCAP upload flow")
+        return jsonify({
+            "error": "Request could not be processed."
+        }), 400
 
     # create the PR only if the branch doesn't already exist
     resp =  pr_exists(user,branch_name,token)

--- a/gitmud/gitmud/app.py
+++ b/gitmud/gitmud/app.py
@@ -654,7 +654,7 @@ def do_the_rest():
                 "sha": (resp.get("content") or {}).get("sha"),
             })
 
-    except GithubProblem as e:
+    except GithubProblem:
         log.exception("GitHub operation failed during MUD/PCAP upload flow")
         return jsonify({
             "error": "Request could not be processed."


### PR DESCRIPTION
Potential fix for [https://github.com/iot-onboarding/mudmaker/security/code-scanning/8](https://github.com/iot-onboarding/mudmaker/security/code-scanning/8)

To fix this, avoid returning raw exception text to clients. Instead:

- Log the exception on the server for diagnostics (`log.exception(...)`), which preserves traceback internally.
- Return a generic, non-sensitive error payload/message to the client with the same status code (400) to preserve behavior.

Best single change in `gitmud/gitmud/app.py` (around lines 657–658):
- Replace `return str(e), 400` with a server-side log call plus a generic response (for consistency with nearby JSON responses, return `jsonify({...}), 400`).

No new imports are needed because `log` and `jsonify` are already present.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
