### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/gitmud/gitmud/app.py
+++ b/gitmud/gitmud/app.py
@@ -406,8 +406,9 @@ def complete_oauth():
         code = None
         if "got_token" not in req:
             code = req["code"]
-    except KeyError as e:
-        return 'KeyError: ' + str(e), 400
+    except KeyError:
+        log.warning("complete_oauth missing required request field", exc_info=True)
+        return "invalid request payload", 400
 
     token = token_in_db(mudurl)
     user = get_gituser(token) if token else False


### PR DESCRIPTION
Potential fix for [https://github.com/iot-onboarding/mudmaker/security/code-scanning/2](https://github.com/iot-onboarding/mudmaker/security/code-scanning/2)

To fix this safely without changing functionality, keep returning HTTP 400 for malformed/missing fields, but stop including exception details in the response body.

Best change in `gitmud/gitmud/app.py` (inside `complete_oauth`, around lines 404–411):
- Replace `return 'KeyError: ' + str(e), 400` with a generic message such as `"invalid request payload", 400`.
- Log the exception on the server using the existing logger (`log`) with `exc_info=True`, so debugging information remains available internally.
- No new imports are needed; `logging` and `log` already exist.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
