### PR TITLE
Visualizer empty-state: drag-and-drop tip + chrome cleanup

### DIFF
--- a/assets/js/mudmaker-visualizer.js
+++ b/assets/js/mudmaker-visualizer.js
@@ -790,14 +790,23 @@
 
 	function drawEmpty(svg, model) {
 		var device = { x: 180, y: 300 };
-		drawNode(svg, device, model.deviceLabel, "MUD file", "device");
-		svg.appendChild(textNode("text", {
-			x: 450,
+		drawNode(svg, device, model.deviceLabel, "", "device");
+		var tipText = createSvg("text", {
+			x: 335,
 			y: 410,
 			class: "mud-live-empty-title"
-		}, "No access-list entries yet"));
-		// Call-to-action sits below the legend (which now hosts the
-		// drag-and-drop tip) so it doesn't compete with the heading.
+		});
+		tipText.appendChild(createSvg("tspan", {
+			x: 335,
+			dy: "0",
+			text: "Tip: drop a MUD .json or .pcap here."
+		}));
+		tipText.appendChild(createSvg("tspan", {
+			x: 335,
+			dy: "1.2em",
+			text: "Shift-drop replaces, plain drop merges."
+		}));
+		svg.appendChild(tipText);
 		svg.appendChild(textNode("text", {
 			x: 450,
 			y: 614,
@@ -866,13 +875,6 @@
 			y: y - 3,
 			class: "mud-live-legend-text"
 		}, "other enterprise access"));
-		// Drop-target tip lives in the legend so it remains visible in
-		// both the empty and the populated state.
-		svg.appendChild(textNode("text", {
-			x: 445,
-			y: y + 29,
-			class: "mud-live-legend-text mud-live-legend-tip"
-		}, "Tip: drop a MUD .json or .pcap here. Shift-drop replaces, plain drop merges."));
 	}
 
 	function drawModel(svg, model) {
@@ -905,7 +907,7 @@
 			});
 			drawNode(svg, positions[endpoint.id], endpoint.label, related.length + " flow" + (related.length === 1 ? "" : "s"), endpoint.kind);
 		});
-		drawNode(svg, device, model.deviceLabel, "MUD file", "device");
+		drawNode(svg, device, model.deviceLabel, "", "device");
 	}
 
 	function renderDetails(model) {


### PR DESCRIPTION
## Summary

Polishes the live MUD visualizer's empty state and removes redundant labeling so the panel reads more clearly when no ACEs have been added yet.

## Changes

All changes are in `assets/js/mudmaker-visualizer.js`:

- **Replace "No access-list entries yet" with an actionable tip.** The empty-state heading now reads:
  > Tip: drop a MUD .json or .pcap here.
  > Shift-drop replaces, plain drop merges.

  The text is split across two SVG `<tspan>` lines (`dy="1.2em"`) so it fits comfortably without overflowing.
- **Center the tip inside the Enterprise box.** The text anchor moved from `x=450` to `x=335`, the horizontal center of the enterprise border (`x=55..615`). Combined with the existing `text-anchor: middle` on `.mud-live-empty-title`, the tip is now visually centered within the box.
- **Drop the "MUD file" subtitle under the device node** in both the empty (`drawEmpty`) and populated (`drawModel`) renderings. The device icon and label are self-explanatory; the subtitle was visual noise.
- **Remove the duplicate drag-and-drop tip from the legend** (`drawLegend`). With the tip front-and-center in the empty state, the legend version was redundant.
- Removed the now-stale comment in `drawEmpty()` that referenced the legend as the home of the drop tip.

## Testing

- Manual: rebuilt the `mudmaker` container (`docker compose up -d --build mudmaker`) and verified the empty state, the populated state after dropping a sample file, and that the legend still renders correctly without the tip line.
- No JS behavior changes; only SVG content and positioning.
