### PR TITLE
Potential fix for code scanning alert no. 10: Uncontrolled command line

### DIFF
--- a/gitmud/gitmud/app.py
+++ b/gitmud/gitmud/app.py
@@ -15,6 +15,7 @@ import base64
 import configparser
 from pathlib import Path
 from time import sleep
+from urllib.parse import urlparse
 from flask import Flask,request, jsonify
 import requests
 
@@ -751,8 +752,9 @@ def pcap2mud():
                       "w", encoding="ascii") as fh:
                 fh.write(mac + "\n")
 
-        _SAFE_ARG_RE = re.compile(r"^[A-Za-z0-9._:/?#\[\]@!$&'()*+,;=%\- ]+$")
-        def _validated_cli_value(field_name, raw_value, max_len=512):
+        _SAFE_TEXT_ARG_RE = re.compile(r"^[A-Za-z0-9._,()\- ]+$")
+
+        def _validated_text_cli_value(field_name, raw_value, max_len=128):
             if raw_value is None:
                 return None
             value = raw_value.strip()
@@ -760,20 +762,33 @@ def pcap2mud():
                 return None
             if len(value) > max_len:
                 raise ValueError(f"{field_name} is too long")
-            if not _SAFE_ARG_RE.match(value):
+            if not _SAFE_TEXT_ARG_RE.fullmatch(value):
                 raise ValueError(f"invalid characters in {field_name}")
+            return value
+
+        def _validated_url_cli_value(field_name, raw_value, max_len=512):
+            if raw_value is None:
+                return None
+            value = raw_value.strip()
+            if not value:
+                return None
+            if len(value) > max_len:
+                raise ValueError(f"{field_name} is too long")
+            parsed = urlparse(value)
+            if parsed.scheme not in ("http", "https") or not parsed.netloc:
+                raise ValueError(f"invalid URL in {field_name}")
             return value
 
         argv = [sys.executable, str(script), workdir]
         try:
-            for opt, field_name in (
-                ("--mfg", "mfg"),
-                ("--model", "model"),
-                ("--systeminfo", "systeminfo"),
-                ("--documentation", "documentation"),
-                ("--mud-url", "mud_url"),
+            for opt, field_name, validator in (
+                ("--mfg", "mfg", _validated_text_cli_value),
+                ("--model", "model", _validated_text_cli_value),
+                ("--systeminfo", "systeminfo", _validated_text_cli_value),
+                ("--documentation", "documentation", _validated_url_cli_value),
+                ("--mud-url", "mud_url", _validated_url_cli_value),
             ):
-                value = _validated_cli_value(field_name, request.form.get(field_name))
+                value = validator(field_name, request.form.get(field_name))
                 if value:
                     argv += [opt, value]
         except ValueError as exc:


### PR DESCRIPTION
Potential fix for [https://github.com/iot-onboarding/mudmaker/security/code-scanning/10](https://github.com/iot-onboarding/mudmaker/security/code-scanning/10)

General fix: ensure user input cannot directly shape command-line semantics beyond explicitly permitted values/formats. Keep the command and option names hard-coded, and strictly validate each user-supplied value according to its expected type.

Best targeted fix in `gitmud/gitmud/app.py` (around lines 754–779): replace the broad `_SAFE_ARG_RE` “generic safe chars” validator with **field-specific validators**:
- text fields (`mfg`, `model`, `systeminfo`): conservative character allowlist and length bound.
- URL fields (`documentation`, `mud_url`): parse with `urllib.parse.urlparse`, require `http`/`https`, non-empty hostname, length bound.
- keep existing hard-coded option mapping and `argv += [opt, value]`.
This preserves functionality while eliminating broad arbitrary argument content and makes the trust boundary explicit.

No new third-party dependency is needed; use Python stdlib `urllib.parse`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
