### PR TITLE
Potential fix for code scanning alert no. 1: Reflected server-side cross-site scripting

### DIFF
--- a/gitmud/gitmud/app.py
+++ b/gitmud/gitmud/app.py
@@ -16,7 +16,7 @@ import configparser
 from pathlib import Path
 from time import sleep
 from urllib.parse import urlparse
-from flask import Flask,request, jsonify
+from flask import Flask,request, jsonify, escape
 import requests
 
 log = logging.getLogger("gitmud")
@@ -672,8 +672,8 @@ def do_the_rest():
     return {
         "mfg" : mfg,
         "model" : model,
-        "user" : user,
-        "mudurl" : mudurl,
+        "user" : escape(user),
+        "mudurl" : escape(mudurl),
         "pcaps" : pcaps_result,
     }, 200
 


### PR DESCRIPTION
Potential fix for [https://github.com/iot-onboarding/mudmaker/security/code-scanning/1](https://github.com/iot-onboarding/mudmaker/security/code-scanning/1)

To fix this safely without changing endpoint behavior, sanitize/escape user-provided values before including them in response fields that are reflected back to clients.

Best concrete change in `gitmud/gitmud/app.py`:
- Update Flask imports to include `escape`.
- In `do_the_rest()`, at the final return block (around lines 672–678), escape the tainted string fields before returning:
  - `"user": escape(user)`
  - `"mudurl": escape(mudurl)`
- Keep all other logic and status codes unchanged.

This preserves functionality (still returns same keys/data semantics) while neutralizing HTML/script payloads in reflected strings.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
