### PR TITLE
Fix /oAuthv2 client/server got_token mismatch causing 'Authenticating...failed'

### DIFF
--- a/assets/js/omud.js
+++ b/assets/js/omud.js
@@ -166,7 +166,7 @@ function oAuthP2(){
       email : email
     }
     if ( got_tok != null ) {
-      jsonbody["got_tok"] = true;
+      jsonbody["got_token"] = true;
     } else {
       if (state !== localStorage.getItem("latestCSRFToken")) {
         localStorage.removeItem("latestCSRFToken");

--- a/gitmud/gitmud/app.py
+++ b/gitmud/gitmud/app.py
@@ -398,6 +398,8 @@ def complete_oauth():
         token: a token to commplete OAUTH
         OR
         got_token, signalling that no github dance is required.
+        (``got_tok`` is accepted as a legacy alias so that older
+        client builds still in browser caches keep working.)
     Returns: 200/400/401
     """
     req=request.json
@@ -405,7 +407,9 @@ def complete_oauth():
     try:
         mudurl = req['mudurl']
         code = None
-        if "got_token" not in req:
+        # ``got_token`` is the canonical flag; ``got_tok`` is the
+        # historical client spelling kept for backward compatibility.
+        if "got_token" not in req and "got_tok" not in req:
             code = req["code"]
     except KeyError:
         log.warning("complete_oauth missing required request field", exc_info=True)

--- a/tests/test_oauth_complete.py
+++ b/tests/test_oauth_complete.py
@@ -1,0 +1,75 @@
+"""Tests for the /oAuthv2 entry point in gitmud.
+
+The endpoint exists so the client can either:
+
+  * complete a fresh GitHub OAuth dance (by passing a ``code``), or
+  * tell the server "I already have a token cached server-side, just
+    look it up and confirm" by setting a sentinel boolean field.
+
+Historically the client and server disagreed about the sentinel name
+(client sent ``got_tok``; server checked for ``got_token``), so the
+no-dance branch was unreachable and any "I already have a token"
+request returned ``invalid request payload (400)``.  This test pins
+both spellings so the regression cannot return.
+
+Run from the repository root:
+    python3 tests/test_oauth_complete.py
+"""
+import json
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "gitmud" / "gitmud"))
+
+import app  # noqa: E402
+
+
+def install_fakes(user="alice", token="tok"):
+    """Stub out the DB + GitHub helpers so the endpoint is offline."""
+    app.token_in_db = lambda mudurl: token
+    app.get_gituser = lambda tok: user if tok == token else None
+    # Should never be reached in the no-code paths exercised here.
+    app.delete_token = lambda mudurl: None
+
+
+def post(client, payload):
+    return client.post(
+        "/oAuthv2",
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+
+
+def main():
+    install_fakes()
+    app.app.config["TESTING"] = True
+    client = app.app.test_client()
+
+    # Canonical spelling: server should not demand "code", look up the
+    # stored token, and return the user it resolves to.
+    resp = post(client, {"mudurl": "https://example.com/m.json",
+                         "got_token": True})
+    assert resp.status_code == 200, (resp.status_code, resp.get_data(as_text=True))
+    assert resp.get_json() == {"user": "alice"}, resp.get_json()
+    print("ok got_token=true: stored token resolved without a code")
+
+    # Legacy spelling: must continue to work so old client builds in
+    # browser caches do not 400.
+    resp = post(client, {"mudurl": "https://example.com/m.json",
+                         "got_tok": True})
+    assert resp.status_code == 200, (resp.status_code, resp.get_data(as_text=True))
+    assert resp.get_json() == {"user": "alice"}, resp.get_json()
+    print("ok got_tok=true: legacy spelling still honoured")
+
+    # Neither flag and no code -> still a 400 because the request is
+    # genuinely incomplete.
+    resp = post(client, {"mudurl": "https://example.com/m.json"})
+    assert resp.status_code == 400, (resp.status_code, resp.get_data(as_text=True))
+    print("ok missing both flag and code: 400 as expected")
+
+    print("OK")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Accept `got_token` from the OAuth-complete client

Fixes a long-standing mismatch between the mudmaker JavaScript and the
gitmud `/oAuthv2` endpoint.

## Symptom

After publishing a MUD file, the client renders:

```
To the user: Authenticating...failedinvalid request payload
```

and the gitmud log shows:

```
WARNING gitmud: complete_oauth missing required request field
Traceback (most recent call last):
  File "/opt/venv/lib/python3.14/site-packages/gitmud/app.py", line 410,
        in complete_oauth
    code = req["code"]
KeyError: 'code'
```

## Cause

The "I already have a token cached server-side, please just look it up
and confirm" path of `/oAuthv2` is gated on a sentinel boolean in the
request body. The client posts that sentinel under the name
`got_tok`:

```js
// assets/js/omud.js
if (got_tok != null) {
  jsonbody["got_tok"] = true;
}
```

…but the server has always checked for `got_token`:

```python
# gitmud/gitmud/app.py
if "got_token" not in req:
    code = req["code"]    # KeyError here when neither name is present
```

So every cache-hit POST falls through to `req["code"]`, raises
`KeyError`, and the endpoint returns `invalid request payload, 400`.
The mismatch has been there since the original OAuth1 PR (#46,
February 2025); this PR is not related to or caused by #102 — that
just happens to be the build currently in production where the bug
finally surfaced.

## Fix

* `gitmud/gitmud/app.py`: the no-dance path now triggers on **either**
  `got_token` (canonical) or `got_tok` (legacy). The legacy spelling
  is documented as an alias kept for backward compatibility with
  client copies already cached in browsers.
* `assets/js/omud.js`: now sends the canonical `got_token` key.
* New `tests/test_oauth_complete.py` (3 cases): asserts that both
  spellings succeed and that a request missing both still returns
  400.

## Verification

`python3 tests/test_oauth_complete.py` — OK (3 checks)
`python3 tests/test_publish_multi.py` — OK (regression, 4 cases)
