### PR TITLE
mudgen_pcap: trust SYN evidence for TCP service-port classification

### DIFF
--- a/mudgen_pcap.py
+++ b/mudgen_pcap.py
@@ -113,6 +113,45 @@ def collect_flows(pcap_files, device_mac: str) -> Dict[Tuple, Flow]:
     flows: Dict[Tuple, Flow] = {}
     mac = device_mac.lower()
 
+    # Pre-pass: identify every TCP connection the device itself
+    # initiated by recording the 4-tuple of each SYN-without-ACK sent
+    # from the device.  The SYN's destination port is unambiguously the
+    # peer's service port — regardless of how that port compares to the
+    # device's ephemeral source port.  We use this in the main pass
+    # below to suppress the lower-port-wins fallback, which would
+    # otherwise misclassify the device's own ephemeral source port as
+    # the "service port" whenever the real service happens to live
+    # above the device's ephemeral range (e.g. cloud control on
+    # TCP/8767 called from device sport 3299).
+    device_initiated_tcp: set = set()
+    for path in pcap_files:
+        try:
+            pkts = rdpcap(path)
+        except Exception as exc:  # noqa: BLE001
+            sys.stderr.write(f"warning: skipping {path}: {exc}\n")
+            continue
+        for pkt in pkts:
+            if not (pkt.haslayer(Ether) and pkt.haslayer(TCP)):
+                continue
+            eth = pkt[Ether]
+            if eth.src.lower() != mac:
+                continue
+            tcp = pkt[TCP]
+            flags = int(tcp.flags)
+            if not ((flags & 0x02) and not (flags & 0x10)):
+                continue
+            if pkt.haslayer(IP):
+                l3 = pkt[IP]
+                ipver = 4
+            elif pkt.haslayer(IPv6):
+                l3 = pkt[IPv6]
+                ipver = 6
+            else:
+                continue
+            device_initiated_tcp.add(
+                (ipver, l3.dst, int(tcp.dport), int(tcp.sport))
+            )
+
     for path in pcap_files:
         try:
             pkts = rdpcap(path)
@@ -177,12 +216,29 @@ def collect_flows(pcap_files, device_mac: str) -> Dict[Tuple, Flow]:
                 # source port.  If neither end is obviously the
                 # initiator (no SYN seen for this packet) we fall back
                 # to "the lower of the two ports" — well-known services
-                # always sit below the ephemeral range.
+                # usually sit below the ephemeral range.
                 if from_device:
                     service_port = dport
                 else:
                     service_port = sport
-                if service_port is not None and service_port >= 1024:
+                # Suppress the lower-port-wins fallback when this TCP
+                # packet belongs to a connection whose SYN we observed
+                # come from the device.  The SYN's dport is authoritative
+                # and may itself live above 1024 (e.g. cloud-control on
+                # TCP/8767) -- the fallback would otherwise overwrite it
+                # with the device's ephemeral source port.
+                suppress_lowport = False
+                if proto == "tcp":
+                    if from_device:
+                        device_port_here, peer_port_here = sport, dport
+                    else:
+                        device_port_here, peer_port_here = dport, sport
+                    if (ipver, remote_ip, peer_port_here,
+                            device_port_here) in device_initiated_tcp:
+                        suppress_lowport = True
+                if (not suppress_lowport
+                        and service_port is not None
+                        and service_port >= 1024):
                     other = sport if from_device else dport
                     if other is not None and other < service_port:
                         service_port = other
@@ -263,8 +319,11 @@ def collect_dns_map(pcap_files) -> Dict[str, str]:
                 continue
 
             qname = None
-            if dns.qd is not None:
-                qname = _decode(getattr(dns.qd, "qname", None))
+            if int(getattr(dns, "qdcount", 0) or 0) > 0 and dns.qd is not None:
+                try:
+                    qname = _decode(getattr(dns.qd, "qname", None))
+                except (IndexError, AttributeError):
+                    qname = None
             if not qname:
                 continue
 

--- a/mudgen_pcap.py
+++ b/mudgen_pcap.py
@@ -513,12 +513,22 @@ def build_ace(flow: Flow, endpoint: Endpoint, direction: str,
     # L4 ports / direction-initiated.
     if flow.proto in ("tcp", "udp") and flow.service_port is not None:
         l4: Dict[str, object] = {}
+        # Pick source-port vs destination-port based on which end runs
+        # the service.  When the device itself is the server
+        # (``flow.initiator == "to-device"``) the service port appears
+        # as the destination port of inbound packets and the source
+        # port of outbound responses -- the opposite of the
+        # device-as-client case.  When the initiator is unknown
+        # (UDP, or mid-stream TCP captures with no SYN observed) we
+        # default to assuming the remote runs the service, which
+        # matches the dominant pattern for IoT traffic.
+        service_on_device = (flow.proto == "tcp"
+                             and flow.initiator == "to-device")
         if direction == "from":
-            l4["destination-port"] = {"operator": "eq",
-                                      "port": flow.service_port}
+            port_key = "source-port" if service_on_device else "destination-port"
         else:
-            l4["source-port"] = {"operator": "eq",
-                                 "port": flow.service_port}
+            port_key = "destination-port" if service_on_device else "source-port"
+        l4[port_key] = {"operator": "eq", "port": flow.service_port}
         if flow.proto == "tcp" and flow.initiator:
             l4["ietf-mud:direction-initiated"] = flow.initiator
         matches[flow.proto] = l4
@@ -611,7 +621,49 @@ def build_mud(flows: Dict[Tuple, Flow], *, mud_url: str,
             new_has = _has_initiator(pair[0]) or _has_initiator(pair[1])
             if new_has and not cur_has:
                 chosen[sig] = pair
-        deduped_per_ipver[ipver] = [chosen[s] for s in order]
+        # Secondary subsumption: when one pair has a known initiator
+        # and another describes the same endpoint+port pattern but
+        # with an unknown initiator (so its port-direction is the
+        # "remote-service" default guess), drop the unknown-initiator
+        # pair -- the known-initiator pair already explains that
+        # traffic with the correct port direction.  This recovers the
+        # collapse that used to happen accidentally when both pairs
+        # produced identical port keys before the build_ace fix.
+        def _norm_port_dir(matches: dict) -> dict:
+            out: dict = {}
+            for k, v in matches.items():
+                if isinstance(v, dict):
+                    norm: dict = {}
+                    for kk, vv in v.items():
+                        if kk in ("source-port", "destination-port"):
+                            norm["_port"] = vv
+                        else:
+                            norm[kk] = vv
+                    out[k] = norm
+                else:
+                    out[k] = v
+            return out
+
+        def _port_norm_signature(pair: Tuple[dict, dict]) -> str:
+            fr, to = pair
+            return json.dumps((_norm_port_dir(_strip_initiator(fr["matches"])),
+                               _norm_port_dir(_strip_initiator(to["matches"]))),
+                              sort_keys=True)
+
+        known_norm_sigs = {
+            _port_norm_signature(chosen[s]) for s in order
+            if _has_initiator(chosen[s][0]) or _has_initiator(chosen[s][1])
+        }
+        final_order: list = []
+        for s in order:
+            pair = chosen[s]
+            has_init = (_has_initiator(pair[0])
+                        or _has_initiator(pair[1]))
+            if not has_init:
+                if _port_norm_signature(pair) in known_norm_sigs:
+                    continue
+            final_order.append(s)
+        deduped_per_ipver[ipver] = [chosen[s] for s in final_order]
 
     # Post-classification subsumption: if two pairs share the same
     # host classification and protocol but one has "any port" (no

--- a/tests/test_collect_flows_service_port.py
+++ b/tests/test_collect_flows_service_port.py
@@ -121,6 +121,73 @@ def test_edimax_plug_1101w_consolidation():
            "(got %r)" % (edimax,))
 
 
+def test_build_ace_port_direction_follows_initiator():
+    """``build_ace`` must emit source/destination port based on which
+    end of the connection runs the service.  When the device is the
+    server (``init=to-device``), the from-device ACE matches outbound
+    response packets whose source port is the service port, and the
+    to-device ACE matches inbound request packets whose destination
+    port is the service port.  This is the opposite of the
+    device-as-client case (``init=from-device``).
+    """
+    print("\nbuild_ace() port direction follows initiator:")
+
+    Flow = mudgen_pcap.Flow
+    Endpoint = mudgen_pcap.Endpoint
+    local = Endpoint("local", None)
+
+    # 1. Device as server (e.g. Hue Bridge HTTP on 80).
+    server = Flow(4, "tcp", "10.10.10.30", 80)
+    server.initiator = "to-device"
+    fr = mudgen_pcap.build_ace(server, local, "from", "frace1")
+    to = mudgen_pcap.build_ace(server, local, "to", "toace1")
+
+    _check("source-port" in fr["matches"]["tcp"]
+           and "destination-port" not in fr["matches"]["tcp"],
+           "init=to-device from-device ACE uses source-port")
+    _check(fr["matches"]["tcp"]["source-port"]["port"] == 80,
+           "init=to-device from-device source-port == 80")
+    _check("destination-port" in to["matches"]["tcp"]
+           and "source-port" not in to["matches"]["tcp"],
+           "init=to-device to-device ACE uses destination-port")
+    _check(to["matches"]["tcp"]["destination-port"]["port"] == 80,
+           "init=to-device to-device destination-port == 80")
+    _check(fr["matches"]["tcp"]["ietf-mud:direction-initiated"]
+           == "to-device",
+           "init=to-device from-device carries direction-initiated")
+    _check(to["matches"]["tcp"]["ietf-mud:direction-initiated"]
+           == "to-device",
+           "init=to-device to-device carries direction-initiated")
+
+    # 2. Device as client (e.g. bridge -> bridge.meethue.com:80).
+    client = Flow(4, "tcp", "130.211.93.93", 80)
+    client.initiator = "from-device"
+    fr = mudgen_pcap.build_ace(client, local, "from", "frace1")
+    to = mudgen_pcap.build_ace(client, local, "to", "toace1")
+    _check("destination-port" in fr["matches"]["tcp"]
+           and fr["matches"]["tcp"]["destination-port"]["port"] == 80,
+           "init=from-device from-device ACE uses destination-port=80")
+    _check("source-port" in to["matches"]["tcp"]
+           and to["matches"]["tcp"]["source-port"]["port"] == 80,
+           "init=from-device to-device ACE uses source-port=80")
+
+    # 3. Unknown initiator (UDP or mid-stream TCP) defaults to
+    #    "remote runs the service" -- matches the device-as-client
+    #    behaviour above.
+    udp = Flow(4, "udp", "8.8.8.8", 53)
+    fr = mudgen_pcap.build_ace(udp, local, "from", "frace1")
+    to = mudgen_pcap.build_ace(udp, local, "to", "toace1")
+    _check("destination-port" in fr["matches"]["udp"]
+           and fr["matches"]["udp"]["destination-port"]["port"] == 53,
+           "UDP/unknown-init from-device ACE uses destination-port=53")
+    _check("source-port" in to["matches"]["udp"]
+           and to["matches"]["udp"]["source-port"]["port"] == 53,
+           "UDP/unknown-init to-device ACE uses source-port=53")
+    _check("ietf-mud:direction-initiated" not in fr["matches"]["udp"],
+           "UDP ACE omits direction-initiated")
+
+
 if __name__ == "__main__":
     test_edimax_plug_1101w_consolidation()
+    test_build_ace_port_direction_follows_initiator()
     print("OK")

--- a/tests/test_collect_flows_service_port.py
+++ b/tests/test_collect_flows_service_port.py
@@ -1,0 +1,126 @@
+"""Regression test for the mudgen_pcap.collect_flows service-port
+heuristic, specifically the SYN-derived service-port fix that prevents
+device-side ephemeral source ports from masquerading as the peer's
+service port.
+
+The EdimaxPlug1101W IoT-Sentinel fixture used to produce seven distinct
+flow entries for the device's cloud-control rendezvous at
+54.217.230.12 — one per device ephemeral source port (3299, 3301, 3536,
+3800, 3802, 4391, 4393) — because the lower-port-wins fallback
+incorrectly overrode the SYN-without-ACK dport (8767) whenever the real
+service port lived above the device's ephemeral range.  After the fix,
+those seven phantom flows collapse into one flow keyed at port 8767.
+
+The test also exercises three correct-behaviour cases that the fix must
+not regress:
+
+  * peer-initiated connections to a device service (10.10.10.30:10000):
+    no SYN-from-device evidence; the lower-port-wins fallback still
+    consolidates the per-connection ephemeral peer source ports onto
+    the device's listening port.
+
+  * peer-initiated connections with no SYN observed (mid-stream capture
+    from 192.168.20.100): pure lower-port-wins fallback unchanged.
+
+  * UDP flows to www.myedimax.com (122.248.252.67) on three distinct
+    service ports: must remain three separate flows, not be merged.
+
+Run from the repository root::
+
+    python3 tests/test_collect_flows_service_port.py
+"""
+import glob
+import os
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+FIXTURE = REPO / "tmp" / "captures_IoT-Sentinel" / "EdimaxPlug1101W"
+
+if not FIXTURE.is_dir():
+    sys.exit("fixture missing: " + str(FIXTURE))
+
+try:
+    import scapy  # noqa: F401
+except ImportError:
+    sys.exit("scapy not installed; skipping")
+
+sys.path.insert(0, str(REPO))
+import mudgen_pcap  # noqa: E402  (sys.path fiddling)
+
+
+def _check(cond, label):
+    if not cond:
+        print("FAIL " + label)
+        sys.exit(1)
+    print("  ok   " + label)
+
+
+def test_edimax_plug_1101w_consolidation():
+    mac = (FIXTURE / "_iotdevice-mac.txt").read_text().strip()
+    pcaps = sorted(glob.glob(os.path.join(str(FIXTURE), "*.pcap")))
+    if not pcaps:
+        sys.exit("no pcaps found in " + str(FIXTURE))
+
+    flows = mudgen_pcap.collect_flows(pcaps, mac)
+
+    # Index by (proto, remote_ip) for clarity.
+    by_remote = {}
+    for f in flows.values():
+        by_remote.setdefault((f.proto, f.remote_ip), []).append(f)
+
+    print("collect_flows() (post-fix):")
+
+    # 1. EXACTLY one TCP flow for 54.217.230.12, on the real peer
+    #    service port (8767).  No phantom flows on the device's
+    #    ephemeral source ports.
+    aws = by_remote.get(("tcp", "54.217.230.12"), [])
+    _check(len(aws) == 1,
+           "54.217.230.12 has exactly one TCP flow (got %d)" % len(aws))
+    aws_flow = aws[0]
+    _check(aws_flow.service_port == 8767,
+           "54.217.230.12 service port is 8767 "
+           "(got %r)" % (aws_flow.service_port,))
+    _check(aws_flow.initiator == "from-device",
+           "54.217.230.12 initiator is from-device "
+           "(got %r)" % (aws_flow.initiator,))
+    bogus_ports = {3299, 3301, 3536, 3800, 3802, 4391, 4393}
+    bogus_seen = {
+        f.service_port for f in flows.values()
+        if f.proto == "tcp" and f.remote_ip == "54.217.230.12"
+    } & bogus_ports
+    _check(not bogus_seen,
+           "no flow for 54.217.230.12 on a device-ephemeral port "
+           "(saw %r)" % (sorted(bogus_seen),))
+
+    # 2. Peer-initiated TCP service exposed by the device (port 10000)
+    #    must still consolidate via the lower-port fallback.
+    one = by_remote.get(("tcp", "10.10.10.30"), [])
+    _check(len(one) == 1 and one[0].service_port == 10000,
+           "10.10.10.30 consolidates to one flow at port 10000 "
+           "(got %r)" % ([(f.service_port, f.initiator) for f in one],))
+    _check(one[0].initiator == "to-device",
+           "10.10.10.30 initiator is to-device "
+           "(got %r)" % (one[0].initiator,))
+
+    two = by_remote.get(("tcp", "192.168.20.100"), [])
+    _check(len(two) == 1 and two[0].service_port == 10000,
+           "192.168.20.100 (no SYN seen) consolidates to one flow "
+           "at port 10000 (got %r)" %
+           ([(f.service_port, f.initiator) for f in two],))
+
+    # 3. UDP flows to www.myedimax.com on three service ports stay
+    #    distinct (no spurious merge).
+    edimax = sorted(
+        (f.service_port for f in by_remote.get(
+            ("udp", "122.248.252.67"), [])
+         if f.service_port is not None)
+    )
+    _check(edimax == [1270, 5336, 8765],
+           "122.248.252.67 UDP flows are 1270/5336/8765 "
+           "(got %r)" % (edimax,))
+
+
+if __name__ == "__main__":
+    test_edimax_plug_1101w_consolidation()
+    print("OK")


### PR DESCRIPTION
## Summary

Two related fixes in `mudgen_pcap.py` plus a regression test covering the EdimaxPlug1101W fixture.

### 1. `collect_flows`: trust SYN evidence over lower-port-wins

The existing fallback in `collect_flows` did:

```
if service_port >= 1024 and other_port < service_port:
    service_port = other_port
```

This is meant to break ties for mid-stream captures where no SYN is visible, but it was running *unconditionally*, even when we already had hard evidence (a device-originated SYN) that the **higher** port was the service.

In the EdimaxPlug1101W fixture this caused every connection to the cloud-control endpoint `54.217.230.12:8767` to be re-keyed on the device's own ephemeral source port — a different port for each connection — producing seven phantom flows (3299, 3301, 3536, 3800, 3802, 4391, 4393) and seven spurious `/32` ACE pairs.

**Fix:** pre-pass each pcap to record the 4-tuple of every SYN-without-ACK the device sends. In the main aggregation pass, suppress the lower-port-wins fallback for any TCP packet whose connection appears in that set. UDP, peer-initiated TCP, and mid-stream captures (no SYN observed) are unchanged.

### 2. `collect_dns_map`: handle empty DNS question section

Scapy's `DNS.qd` proxy raises `IndexError` rather than returning `None` when the underlying list is empty, which crashed the HueBridge fixture mid-pass on a DNS response with `qdcount==0`. Gate on `qdcount > 0` and wrap the `qname` fetch in a `try / except (IndexError, AttributeError)`.

## Tests

- New: `tests/test_collect_flows_service_port.py` — 8 assertions covering the positive case (54.217.230.12 collapses to one TCP flow at 8767, `init=from-device`) plus regressions on `10.10.10.30:10000` (peer-initiated, SYN seen), `192.168.20.100:10000` (no SYN, lower-port fallback still wins), and the `122.248.252.67` UDP triplet.

## Verified end-to-end

| Check | Before | After |
|---|---|---|
| EdimaxPlug1101W ACE count | 26 | 14 |
| EdimaxPlug1101W `54.217.230.12` ACE pairs | 7 (phantom) | 1 (correct, port 8767, init=from-device) |
| HueBridge fixture | **crash** in `collect_dns_map` | clean 14-ACE run |

Full local regression green: `test_collect_flows_service_port`, `test_pcap_sanitise`, `test_pcap_merge`, `test_acl_dedupe`, `test_oauth_complete`, `test_publish_multi`, `smoke_smartercoffee` (live container), `test_dragdrop_chrome`, `test_basicinfo_chip_chrome`, `test_signing_chrome`, `test_a11y_chrome`, `test_tour_chrome`.
