### PR TITLE
mudmaker.js: fix DNS-input pattern to compile under the RegExp `v` flag

### DIFF
--- a/assets/js/mudmaker.js
+++ b/assets/js/mudmaker.js
@@ -357,7 +357,11 @@ function addEntry(entry){
 
 	if ( dnsorurl == 'dns' ) {
 	    typefield="'text'";
-	    pattern = " pattern='[a-z0-9.-]+\.[a-z]{2,3}$'";
+	    // Escape the hyphen (required under the RegExp `v` flag that
+	    // modern browsers now apply to HTML5 pattern attributes) and
+	    // double-escape the literal dot so the backslash actually
+	    // survives into the rendered HTML attribute.
+	    pattern = " pattern='[a-z0-9.\\-]+\\.[a-z]{2,3}$'";
 	    readonly=0;
 	    placeholder=" placeholder='hostname.manufacturer.com'";
 	} else if ( dnsorurl == 'url' ) {


### PR DESCRIPTION
## Bug

On the live site (https://mudmaker.org), the DNS-hostname input rendered by `addEntry()` triggers a console error and stops being validated:

```
Unable to check <input pattern='[a-z0-9.-]+.[a-z]{2,3}$'> because
'/[a-z0-9.-]+.[a-z]{2,3}$/v' is not a valid regexp:
invalid character in class in regular expression
                       mudmaker.js:872:7
```

## Cause

Modern Chrome / Firefox now apply the RegExp `v` flag (Unicode sets, TC39 2024) to HTML5 `pattern` attributes. Under `v`-flag rules, an unescaped `-` inside a character class is legal only at the very edges of the class or as part of an unambiguous range. The pattern `[a-z0-9.-]` has `-` sandwiched between `.` and `]`, which `v` mode flags as ambiguous.

The pattern still compiled in legacy mode (and still works under the `u` flag), which is why this only surfaced in production once the browser flipped the default.

## Fix

Escape the `-` inside the class. While editing, also escape the literal `.` before the TLD — the previous source had `\.` inside a single-quoted JS string, which JS strips to a bare `.`, so the rendered attribute matched *any* character there (`"hostXcom"` passed pattern checks).

Both fixes require doubling the backslash in the JS source so the rendered HTML attribute is `[a-z0-9.\-]+\.[a-z]{2,3}$`.

```diff
-    pattern = " pattern='[a-z0-9.-]+\.[a-z]{2,3}$'";
+    pattern = " pattern='[a-z0-9.\\-]+\\.[a-z]{2,3}$'";
```

## Verification

- New pattern compiles cleanly under both the `v` and `u` flags in Node.
- Still accepts representative valid hostnames (`example.com`, `sub.host-1.io`).
- Still rejects mixed-case (`BadCase.com`) and no-TLD (`no-tld`) inputs.
- Pre-existing 2-3-char-TLD limit unchanged (intentional; not part of this hotfix).
- All three relevant Chrome browser tests pass against the rebuilt `mudmaker` container: `test_dragdrop_chrome`, `test_basicinfo_chip_chrome`, `test_a11y_chrome`.
