### PR TITLE
Potential fix for code scanning alert no. 19: Reflected server-side cross-site scripting

### DIFF
--- a/gitmud/gitmud/app.py
+++ b/gitmud/gitmud/app.py
@@ -675,8 +675,11 @@ def do_the_rest():
             return "PR failed", 400
 
     return {
-        "mfg" : mfg,
-        "model" : model,
+        # ``mfg`` and ``model`` are derived from request-controlled MUD
+        # content and reflected back to the caller; HTML-escape them so
+        # downstream HTML renderers cannot execute injected markup.
+        "mfg" : str(escape(mfg)),
+        "model" : str(escape(model)),
         # ``user`` and ``mudurl`` come from request input and are
         # reflected back to the caller; HTML-escape them so any
         # downstream consumer that renders them as HTML cannot be


### PR DESCRIPTION
Potential fix for [https://github.com/iot-onboarding/mudmaker/security/code-scanning/19](https://github.com/iot-onboarding/mudmaker/security/code-scanning/19)

To fix this without changing functionality, apply HTML escaping to **all** user-derived fields reflected in the response payload, including `mfg` and `model`, just like `user` and `mudurl` are already escaped.

Best single fix in `gitmud/gitmud/app.py`:
- In the return dict in `do_the_rest()` (around lines 677–688), wrap `mfg` and `model` with `escape(...)` and cast to `str`, matching existing style.
- No new imports are needed because `escape` is already imported from `markupsafe` on line 20.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
